### PR TITLE
#5　年月の指定を受けてひと月分の勤怠表示、及び1日分勤務時間計算の共通化

### DIFF
--- a/src/main/java/com/example/springsandbox/controller/EmployeeController.java
+++ b/src/main/java/com/example/springsandbox/controller/EmployeeController.java
@@ -33,7 +33,7 @@ public class EmployeeController {
         EmployeeDto employee = employeeService.getEmployeeDetail(employeeId);
         model.addAttribute("employee", employee);
 //        取得したIDの従業員の勤怠情報を取得してHTMLに渡す
-        String monthOfAttendance = "2023/02";
+        String monthOfAttendance = "2023/01";
         List<AttendanceDto> employeeAttendance = employeeService.getEmployeeAttendance(employeeId, monthOfAttendance);
         model.addAttribute("employeeAttendance", employeeAttendance);
         return "employees/detail";

--- a/src/main/java/com/example/springsandbox/controller/EmployeeController.java
+++ b/src/main/java/com/example/springsandbox/controller/EmployeeController.java
@@ -33,7 +33,8 @@ public class EmployeeController {
         EmployeeDto employee = employeeService.getEmployeeDetail(employeeId);
         model.addAttribute("employee", employee);
 //        取得したIDの従業員の勤怠情報を取得してHTMLに渡す
-        List<AttendanceDto> employeeAttendance = employeeService.getEmployeeAttendance(employeeId);
+        String monthOfAttendance = "2023/02";
+        List<AttendanceDto> employeeAttendance = employeeService.getEmployeeAttendance(employeeId, monthOfAttendance);
         model.addAttribute("employeeAttendance", employeeAttendance);
         return "employees/detail";
     }


### PR DESCRIPTION
お館様に、いくつか確認して頂いたい事項がござ候。

<ひと月分の勤怠表示>
①xmlクラスもいじって、受け取った年/月のみのデータをDBから出力すべきかどうか。
②知っている事と調査したことの知識総動員でコーディングしたが、型変更したり日付を足したりで行が多くなっている。
　（出来るだけ少なくしようと心がけたが･･･）
　もっとスマートに書く方法があればご指南願いたい。

<勤務時間計算の共通化>
③勤務時間をDurationで出力するところまでの共通化にとどめ、String型に変更する部分は含めなかった。理由は以下。

従業員一覧ページで出している合計勤務時間の表示が、Duration型で計算して最後にString型に変更している。
先にString型にしてしまった場合、一度String→Duration型にしてから計算して最後にもう一度String型に直す必要があると思った。
それは無駄手間になるのではと思い、Duration型での出力までを共通化するに留めた。　以上。